### PR TITLE
MAINT: add env file for QIIME 2 2026.1

### DIFF
--- a/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.1.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.1.yml
@@ -6,4 +6,4 @@ dependencies:
   - qiime2-pathogenome
   - pip
   - pip:
-     - "q2-amrfinderplus @ git+https://github.com/bokulich-lab/q2-amrfinderplus.git"
+     - q2-amrfinderplus@git+https://github.com/bokulich-lab/q2-amrfinderplus.git@2026.1.0

--- a/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.1.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.1.yml
@@ -1,0 +1,9 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/pathogenome/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2-pathogenome
+  - pip
+  - pip:
+     - "q2-amrfinderplus @ git+https://github.com/bokulich-lab/q2-amrfinderplus.git"


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2026.1.

Generated from the latest env file in 'environment-files/' by updating the release token.