### PR TITLE
MAINT: remove env file 2024.10 and fixed 2026.4

### DIFF
--- a/environment-files/q2-amrfinderplus-qiime2-pathogenome-2024.10.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-pathogenome-2024.10.yml
@@ -1,9 +1,0 @@
-channels:
-- https://packages.qiime2.org/qiime2/2024.10/pathogenome/released
-- conda-forge
-- bioconda
-dependencies:
-  - qiime2-pathogenome
-  - pip
-  - pip:
-     - "q2-amrfinderplus @ git+https://github.com/bokulich-lab/q2-amrfinderplus.git"

--- a/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.4.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.4.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
-  - qiime2-pathogenome
+  - rachis-pathogenome
   - pip
   - pip:
      - "q2-amrfinderplus@git+https://github.com/bokulich-lab/q2-amrfinderplus.git@2026.4.1"


### PR DESCRIPTION
env file 2024.10 was broken and not needed
env file 2026.4 had the wrong package name 
