### PR TITLE
MAINT: add env file for tiny distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@ QIIME 2 plugin to find acquired antimicrobial resistance genes and point mutatio
 ## Installation
 To install _q2-amrfinderplus_, follow the steps described in the
 [QIIME 2 installation instructions](https://library.qiime2.org/quickstart/pathogenome)
-for the pathogenome distribution.
+for the pathogenome distribution. The pathogenome distribution is only available for
+linux. If you want to install q2-amrfinderplus on macOS you can install it with the
+tiny distribution. For this follow the instructions on the [QIIME2 Library](https://library.qiime2.org/plugins/bokulich-lab/q2-amrfinderplus).
 
 
 ## Functionality
 This QIIME 2 plugin contains actions used to annotate protein sequences MAGs and
 contigs with antimicrobial resistance genes. The underlying tool used is
 [AMRFinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/).
-For details on the package, please refer to the
-[AMRFinderPlus documentation](https://github.com/ncbi/amr/wiki)).
-Checkout the [MOSHPIT docs](https://moshpit.qiime2.org/en/stable/chapters/tutorials/amr-gene-annotation/q2-amrfinderplus/intro/)
-for a tutorial of _q2-amrfinderplus_.
+For a tutorial on the package, please refer to the [MOSHPIT docs](https://moshpit.qiime2.org/en/stable/chapters/tutorials/amr-gene-annotation/q2-amrfinderplus/intro/)
 
 | Action                 | Description                                                                                 |
 |------------------------|---------------------------------------------------------------------------------------------|

--- a/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.1.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.1.yml
@@ -1,9 +1,0 @@
-channels:
-- https://packages.qiime2.org/qiime2/2026.1/pathogenome/released
-- conda-forge
-- bioconda
-dependencies:
-  - qiime2-pathogenome
-  - pip
-  - pip:
-     - q2-amrfinderplus@git+https://github.com/bokulich-lab/q2-amrfinderplus.git@2026.1.0

--- a/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.4.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-pathogenome-2026.4.yml
@@ -4,6 +4,3 @@ channels:
 - bioconda
 dependencies:
   - rachis-pathogenome
-  - pip
-  - pip:
-     - "q2-amrfinderplus@git+https://github.com/bokulich-lab/q2-amrfinderplus.git@2026.4.1"

--- a/environment-files/q2-amrfinderplus-qiime2-tiny-2026.4.yml
+++ b/environment-files/q2-amrfinderplus-qiime2-tiny-2026.4.yml
@@ -1,0 +1,10 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.4/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+  - rachis-tiny
+  - ncbi-amrfinderplus=4.2.7
+  - pip
+  - pip:
+     - "q2-amrfinderplus@git+https://github.com/bokulich-lab/q2-amrfinderplus.git@2026.4.1"


### PR DESCRIPTION
- Adds new env file for tiny distro.
- Modifies pathegenome env file to only install pathogenome distro. 
- Update the README.