### PR TITLE
MAINT: only test changed env files on push/PR

### DIFF
--- a/.github/workflows/test-env-files.yaml
+++ b/.github/workflows/test-env-files.yaml
@@ -15,4 +15,5 @@ jobs:
     uses: bokulich-lab/utilities/.github/workflows/test-env-files.yaml@main
     with:
       environment_dir: environment-files
-      test_all: true   # every file in the dir whenever this runs
+      # Only test new/changed files on push/PR; test everything on a manual run.
+      test_all: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
The `test-env-files` workflow was passing `test_all: true` unconditionally, so every push/PR tested every file in `environment-files/` instead of only the new/changed ones. This sets `test_all` based on the trigger: `false` for push/PR (only changed files are tested, using the reusable workflow's existing changed-file detection), `true` only for a manual `workflow_dispatch` run.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [ ] NO AI USED.
- [x] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
Claude Sonnet 5 was used to automate opening this PR across all the repos.
